### PR TITLE
Update convertitore.c

### DIFF
--- a/convertitore.c
+++ b/convertitore.c
@@ -5,11 +5,11 @@ int main()
     double pollici;
     double centimetri;
     printf("inserisci il valore dei pollici:\n");
-    scanf("%f,&pollici");
+    scanf("%lf", &pollici);
     if(pollici>=0)
     {
-        centimetri=pollici*2,54;
-        printf("i centimetri valgono:\n",centimetri);
+        centimetri = pollici * 2.54;
+        printf("i centimetri valgono:%lf\n", centimetri);
 
     } else
     {


### PR DESCRIPTION
Questa Pull Request modifica degli errori nel codice convertitore.c: 
* La scanf non considerava la formattazione DOUBLE (lf), ma la formattazione FLOAT (f). Inoltre, il double quote non si trovava sul primo argomento prima la virgola, ma circondava anche la variabile pollici (linea 8).
* Il numero 2,54 è stato sostituito da 2.54 (il separatore tra parte decimale e intera è il PUNTO). 
* Aggiunti degli spazi per migliorare la lettura. 
* La printf utilizza lf come formattazione del DOUBLE. 
